### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -9,6 +9,13 @@ jobs:
   merge-to-release-branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@main
 
       - name: Merge main -> release
@@ -17,4 +24,4 @@ jobs:
           type: now
           from_branch: main
           target_branch: release
-          github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -7,10 +7,17 @@ jobs:
   generate-readme:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
